### PR TITLE
configure: fix static linking with openSSL

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -21,6 +21,7 @@ AC_PROG_RANLIB
 AC_LIBTOOL_DLOPEN
 AC_PROG_LIBTOOL
 AC_LANG_CPLUSPLUS
+PKG_PROG_PKG_CONFIG
 
 # Use this to disable all optimisations in order to run with valgrind
 AC_ARG_ENABLE([valgrind],
@@ -119,28 +120,21 @@ AC_ARG_WITH([bluetooth],
 
 # SSL module
 # Include if OpenSSL headers are found
-AC_ARG_WITH([openssl_path],
-  [AC_HELP_STRING([--with-openssl-path=PATH],[Set path to OpenSSL])],
-  [CXXFLAGS="$CXXFLAGS -I$withval/include";],
-)
 AC_ARG_WITH([ssl],
   [AC_HELP_STRING([--with-ssl],[Enable secure sockets module])],
   [SSL="$withval"],
-  [AC_CHECK_HEADER([openssl/ssl.h],[SSL="yes"],[SSL="no"])]
+  [SSL="check"]
 )
-if test "x$SSL" = "xyes"; then
-  AC_CHECK_HEADER([openssl/ssl.h],,
-    [AC_MSG_ERROR([header file <openssl/ssl.h> is required for OpenSSL, use --with-openssl-path=PATH])]
-  )
-  AC_CHECK_LIB([crypto],[CRYPTO_new_ex_data],
-    [SSL_LIBADD="$SSL_LIBADD -lcrypto"],
-    [AC_MSG_ERROR([library 'crypto' is required for OpenSSL])]
-  )
-  AC_CHECK_LIB([ssl],[SSL_library_init],
-    [SSL_LIBADD="$SSL_LIBADD -lssl"],
-    [AC_MSG_ERROR([library 'ssl' is required for OpenSSL])]
-  )
-  AC_SUBST(SSL_LIBADD)
+if test "x$SSL" = "xyes" -o "x$SSL" = "xcheck"; then
+  PKG_CHECK_MODULES(
+    [SSL], [openssl],
+    [SSL=yes],
+    [if test "x$SSL" = "xyes"; then
+      AC_MSG_FAILURE([$SSL_PKG_ERRORS])
+     else
+      AC_MSG_WARN([$SSL_PKG_ERRORS])
+     fi
+     SSL="no"])
 fi
 
 # Example modules

--- a/ssl/Makefile.am
+++ b/ssl/Makefile.am
@@ -18,7 +18,7 @@ SSLStream.h \
 SSLChannel.h
 
 ssl_la_LDFLAGS = -module -avoid-version
-ssl_la_LIBADD = $(SSL_LIBADD)
+ssl_la_LIBADD = $(SSL_LIBS)
 
 modconfdir = $(sysconfdir)/modules.d
 modconf_DATA = ssl.conf


### PR DESCRIPTION
When doing static builds, the ordering of libs is important, as the
linker does not back-pedal to previous libraries specified on the
command line to find missing symbols, and only searches for those
missing symbols in the following libs.

Thus, as -lssl needs symbols from -lcrypto, it needs to come before
-lcrypto. Also, -lcrypto needs -lz, which is entirely missing.

Instead of trying to hand-craft openSSL detection, use pkg-config to
find it; pkg-config will give us all the libraries that are needed to
link in -lssl , without us double-guessing anything! :-)

Signed-off-by: "Yann E. MORIN" yann.morin.1998@free.fr
