### PR TITLE
sconex/base64: fix C++11 compliance with gcc-6

### DIFF
--- a/sconex/Base64.cpp
+++ b/sconex/Base64.cpp
@@ -25,7 +25,7 @@ namespace scx {
 static char basis_64[] =
    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-static char index_64[128] = {
+static int index_64[128] = {
     -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
     -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
     -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,62, -1,-1,-1,63,


### PR DESCRIPTION
gcc-6 has enabled more warnings by default, and turned some existing
warnings into errors.

In C++11, narrowing a type is no longer allowed in structure or array
initialisers:

```
char foo[] = { 0, 1, -1 };
```

results in the gcc-6 whining out loudly, and fail:

```
Base64.cpp:37:1: warning: narrowing conversion of '-1' from 'int' to 'char' inside { } is ill-formed in C++11 [-Wnarrowing]
 };
 ^
```

(and so on ad nauseam...).

Fix that by using `int` as the type of the array. Its content is only
ever assigned to objects that are already `int`s anyway.

Signed-off-by: "Yann E. MORIN" yann.morin.1998@free.fr
