### PR TITLE
sconex/Descriptor.cpp: fix build with gcc 11

### DIFF
--- a/sconex/Descriptor.cpp
+++ b/sconex/Descriptor.cpp
@@ -147,7 +147,7 @@ bool Descriptor::dup(int d)
 //=============================================================================
 void Descriptor::add_stream(Stream* stream)
 {
-  DEBUG_ASSERT(stream>=0,"add_stream() Invalid stream");
+  DEBUG_ASSERT(stream!=0,"add_stream() Invalid stream");
 
   m_streams.push_back(stream);
   stream->set_endpoint(this);
@@ -201,7 +201,7 @@ void Descriptor::add_stream_after(Stream* stream,const Stream* after)
 //=============================================================================
 bool Descriptor::remove_stream(Stream* stream)
 {
-  DEBUG_ASSERT(stream>=0,"remove_stream() Invalid stream");
+  DEBUG_ASSERT(stream!=0,"remove_stream() Invalid stream");
 
   std::list<Stream*>::iterator it = m_streams.begin();
   while (it != m_streams.end()) {


### PR DESCRIPTION
Fix the following build failure with gcc 11:

```
In file included from ../sconex/sconex.h:229,
                 from ../sconex/Descriptor.h:63,
                 from Descriptor.cpp:22:
Descriptor.cpp: In member function 'void scx::Descriptor::add_stream(scx::Stream*)':
Descriptor.cpp:150:22: error: ordered comparison of pointer with integer zero ('scx::Stream*' and 'int')
  150 |   DEBUG_ASSERT(stream>=0,"add_stream() Invalid stream");
      |                ~~~~~~^~~
      |                                 ^~~~
Descriptor.cpp: In member function 'bool scx::Descriptor::remove_stream(scx::Stream*)':
Descriptor.cpp:204:22: error: ordered comparison of pointer with integer zero ('scx::Stream*' and 'int')
  204 |   DEBUG_ASSERT(stream>=0,"remove_stream() Invalid stream");
      |                ~~~~~~^~~
```

Fixes:
 - http://autobuild.buildroot.org/results/ccc9562e83fd2bd312d21b3124be42dfe4b7e850

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>